### PR TITLE
End of MTTD PR

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -152,7 +152,8 @@ public class Constants {
 
 	/** INPUT CONSTANTS */
 	public static final double ELEVATOR_MANUAL_POWER_SCALAR = 1.0;
-	public static final double CARGO_INTAKE_INPUT_MAGNITUDE = 1.0;
+	public static final double CARGO_INTAKE_INPUT_MAGNITUDE = 0.5;
+	public static final double CARGO_OUTTAKE_MAGNITUDE = 1.0;
 	/**
 	 * Seconds
 	 */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -64,6 +64,7 @@ public class Constants {
 	public static final double RADIAL_TURN_SENSITIVITY = 20;
 	public static final double SCALING_POWER = 2.75;
 	public static final double RAMP_RATE = 0.25; // Seconds to go from 0 to full throttle
+	public static final int DRIVE_CURRENT_LIMIT = 60;
 
 	/** Elevator Constants */
 	public static final double BOTTOM_LIMIT_POSITION = 0.0; // In rotations by default but using conversion factors we

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -64,7 +64,10 @@ public class Constants {
 	public static final double RADIAL_TURN_SENSITIVITY = 20;
 	public static final double SCALING_POWER = 2.75;
 	public static final double RAMP_RATE = 0.25; // Seconds to go from 0 to full throttle
-	public static final int DRIVE_CURRENT_LIMIT = 60;
+	public static final int DRIVE_CURRENT_LIMIT = 60; // Amps to limit the drive motors to, removes voltage instead of
+														// stopping. 60 seems better but not exactly correct. Not tested
+														// on the floor, only free spin (40 trips the breaker normally,
+														// 60 is high)
 
 	/** Elevator Constants */
 	public static final double BOTTOM_LIMIT_POSITION = 0.0; // In rotations by default but using conversion factors we
@@ -147,8 +150,11 @@ public class Constants {
 
 	public static final double VACUUM_POWER = 1.0;
 	public static final boolean IS_VACUUM_MOTOR_INVERTED = false;
-	public static final double SENSOR_VOLTS_TO_PSI_SLOPE = 8.99; // Calculated using two points of voltage and PSI and finding the slope
-	public static final double SENSOR_VOLTS_TO_PSI_Y_INTERCEPT = -23.72; // See above. This means that at 0V, it will be -23.72 PSI, which is admittedly inaccurate (should be -14.5) 
+	public static final double SENSOR_VOLTS_TO_PSI_SLOPE = 8.99; // Calculated using two points of voltage and PSI and
+																	// finding the slope
+	public static final double SENSOR_VOLTS_TO_PSI_Y_INTERCEPT = -23.72; // See above. This means that at 0V, it will be
+																			// -23.72 PSI, which is admittedly
+																			// inaccurate (should be -14.5)
 	public static final double VACUUM_PRESSURE_THRESHOLD = SENSOR_VOLTS_TO_PSI_Y_INTERCEPT;
 
 	/** INPUT CONSTANTS */

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -29,6 +29,7 @@ public class OI {
 	public final JoystickWrapper climbController;
 	public final JoystickButton reverseDrive, driveShift;
 	public final JoystickButton hubertOuttake;
+	public final JoystickButton hubertHatchOuttake;
 	public final JoystickButton ohCrapHubert;
 
 	public final JoystickButton hatchLevel1;
@@ -59,6 +60,7 @@ public class OI {
 		reverseDrive = new JoystickButton(driverAController, 1);
 		driveShift = new JoystickButton(driverAController, 2);
 		hubertOuttake = new JoystickButton(driverAController, 7);
+		hubertHatchOuttake = new JoystickButton(driverAController, 8);
 		ohCrapHubert = new JoystickButton(driverAController, 3);
 
 		/** DRIVER B */
@@ -104,6 +106,7 @@ public class OI {
 		reverseDrive.whileHeld(new ReverseDrive());
 		driveShift.whileHeld(new DriveShift());
 		hubertOuttake.whileHeld(new CargoCommand(false, Constants.CARGO_INTAKE_INPUT_MAGNITUDE));
+		hubertHatchOuttake.whenPressed(new OuttakeHatch(Constants.HATCH_EJECT_RETRACT_TIMEOUT));
 		ohCrapHubert.whenPressed(new OhCrap());
 
 		/** DRIVER B */

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -103,7 +103,7 @@ public class OI {
 		/** DRIVER A */
 		reverseDrive.whileHeld(new ReverseDrive());
 		driveShift.whileHeld(new DriveShift());
-		hubertOuttake.whileHeld(new CargoCommand(true, Constants.CARGO_INTAKE_INPUT_MAGNITUDE));
+		hubertOuttake.whileHeld(new CargoCommand(false, Constants.CARGO_INTAKE_INPUT_MAGNITUDE));
 		ohCrapHubert.whenPressed(new OhCrap());
 
 		/** DRIVER B */

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -11,6 +11,7 @@ import frc.robot.subsystems.climb.commands.RunVacuum;
 import frc.robot.subsystems.drive.commands.DriveShift;
 import frc.robot.subsystems.drive.commands.ReverseDrive;
 import frc.robot.subsystems.elevator.commands.ManualElevator;
+import frc.robot.subsystems.elevator.commands.ManualZero;
 import frc.robot.subsystems.elevator.commands.OhCrap;
 import frc.robot.subsystems.superstructure.commands.CargoCommand;
 import frc.robot.subsystems.superstructure.commands.ElevatorAndIntakeHeight;
@@ -31,6 +32,7 @@ public class OI {
 	public final JoystickButton hubertOuttake;
 	public final JoystickButton hubertHatchOuttake;
 	public final JoystickButton ohCrapHubert;
+	public final JoystickButton manualZero;
 
 	public final JoystickButton hatchLevel1;
 	public final JoystickButton hatchLevel2;
@@ -62,6 +64,7 @@ public class OI {
 		hubertOuttake = new JoystickButton(driverAController, 7);
 		hubertHatchOuttake = new JoystickButton(driverAController, 8);
 		ohCrapHubert = new JoystickButton(driverAController, 3);
+		manualZero = new JoystickButton(driverAController, 6);
 
 		/** DRIVER B */
 		driverBController = new JoystickWrapper(1);
@@ -108,6 +111,7 @@ public class OI {
 		hubertOuttake.whileHeld(new CargoCommand(false, Constants.CARGO_OUTTAKE_MAGNITUDE));
 		hubertHatchOuttake.whenPressed(new OuttakeHatch(Constants.HATCH_EJECT_RETRACT_TIMEOUT));
 		ohCrapHubert.whenPressed(new OhCrap());
+		manualZero.whenPressed(new ManualZero());
 
 		/** DRIVER B */
 		toggleIntakeHeight.whenPressed(new ToggleIntakeHeight());

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -105,7 +105,7 @@ public class OI {
 		/** DRIVER A */
 		reverseDrive.whileHeld(new ReverseDrive());
 		driveShift.whileHeld(new DriveShift());
-		hubertOuttake.whileHeld(new CargoCommand(false, Constants.CARGO_INTAKE_INPUT_MAGNITUDE));
+		hubertOuttake.whileHeld(new CargoCommand(false, Constants.CARGO_OUTTAKE_MAGNITUDE));
 		hubertHatchOuttake.whenPressed(new OuttakeHatch(Constants.HATCH_EJECT_RETRACT_TIMEOUT));
 		ohCrapHubert.whenPressed(new OhCrap());
 
@@ -122,7 +122,7 @@ public class OI {
 		intakeHatch.whenPressed(new IntakeHatch());
 		outtakeHatch.whenPressed(new OuttakeHatch(Constants.HATCH_EJECT_RETRACT_TIMEOUT));
 		intakeCargo.whileHeld(new CargoCommand(true, Constants.CARGO_INTAKE_INPUT_MAGNITUDE));
-		outtakeCargo.whileHeld(new CargoCommand(false, Constants.CARGO_INTAKE_INPUT_MAGNITUDE));
+		outtakeCargo.whileHeld(new CargoCommand(false, Constants.CARGO_OUTTAKE_MAGNITUDE));
 
 		/** CLIMB */
 		useManualElevator.whileHeld(new ManualElevator());

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -59,6 +59,7 @@ public class Robot extends TimedRobot {
 	@Override
 	public void robotPeriodic() {
 		SmartDashboard.putBoolean("Is succed", climb.isSuccd());
+		SmartDashboard.putBoolean("Is bottomed", elevator.isBottomed());
 	}
 
 	/**

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -44,6 +44,10 @@ public class Drive extends Subsystem {
 
 		left.setInverted(Constants.IS_LEFT_INVERTED);
 		right.setInverted(Constants.IS_RIGHT_INVERTED);
+
+		left.getMasterMotor().setSmartCurrentLimit(Constants.DRIVE_CURRENT_LIMIT);
+		right.getMasterMotor().setSmartCurrentLimit(Constants.DRIVE_CURRENT_LIMIT);
+		// left.getMasterMotor().setSmartCurrentLimit(stallLimit, freeLimit)
 		isReversed = false;
 	}
 

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -121,14 +121,14 @@ public class Drive extends Subsystem {
 	 * Shift the drivebase to low gear.
 	 */
 	public void shiftLow() {
-		gearShift.set(true);
+		gearShift.set(false);
 	}
 
 	/**
 	 * Shift the drivebase to high gear.
 	 */
 	public void shiftHigh() {
-		gearShift.set(false);
+		gearShift.set(true);
 	}
 
 	@Override

--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -185,6 +185,15 @@ public class Elevator extends Subsystem {
 	 */
 	public void lower(double power) {
 		// High Gear
+		if (!bottomWasPressed) {
+			if (m_bottomLimit.get()) {
+				setPosition(Constants.BOTTOM_LIMIT_POSITION);
+				bottomWasPressed = true;
+			}
+		}
+		if (!m_bottomLimit.get()) {
+			bottomWasPressed = false;
+		}
 		if (getGearState()) {
 			if ((Math.abs(Constants.BOTTOM_LIMIT_POSITION
 					- Robot.elevator.getPosition())) < Constants.ELEVATOR_ROTATION_TOLERANCE_HIGH_GEAR) {
@@ -264,6 +273,10 @@ public class Elevator extends Subsystem {
 
 	public boolean isBottomed() {
 		return m_bottomLimit.get();
+	}
+
+	public void setWasBottomed(boolean wasBottomed) {
+		this.bottomWasPressed = wasBottomed;
 	}
 
 	@Override

--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -234,6 +234,10 @@ public class Elevator extends Subsystem {
 				.setEncPosition(m_elevatorMotors.getEncoderPosition() * Constants.LOW_GEAR_TO_HIGH_GEAR_ROATIONS);
 	}
 
+	public boolean isBottomed() {
+		return m_bottomLimit.get();
+	}
+
 	@Override
 	public void initDefaultCommand() {
 		// No default needed because setting to target keeps going even when a command

--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -27,6 +27,7 @@ public class Elevator extends Subsystem {
 	private final SparkMaxMotorGroup m_elevatorMotors;
 	private final Solenoid m_elevatorShift;
 	private final CANDigitalInput m_topLimit, m_bottomLimit;
+	private boolean bottomWasPressed;
 
 	public Elevator() {
 		final CANSparkMax elevatorMotor1 = new CANSparkMax(Constants.CANIDs.ELEVATOR_M1, MotorType.kBrushless);
@@ -51,6 +52,8 @@ public class Elevator extends Subsystem {
 		// Populate PID slots with the low-gear and high-gear gains
 		configureHighGearPID();
 		configureLowGearPID();
+		bottomWasPressed = false; // False to always run the zero when a setpoint is pressed after turning on the
+									// robot when the elevator is all the way to the bottom
 	}
 
 	/**
@@ -77,7 +80,8 @@ public class Elevator extends Subsystem {
 		pidController.setD(Constants.ELEVATOR_CLIMB_D, Constants.LOW_GEAR_PID_SLOT);
 		pidController.setIZone(Constants.ELEVATOR_CLIMB_I_ZONE, Constants.LOW_GEAR_PID_SLOT);
 		pidController.setFF(Constants.ELEVATOR_CLIMB_F, Constants.LOW_GEAR_PID_SLOT);
-		pidController.setOutputRange(Constants.ELEVATOR_LOW_GEAR_MIN_OUTPUT, Constants.ELEVATOR_LOW_GEAR_MAX_OUTPUT, Constants.LOW_GEAR_PID_SLOT);
+		pidController.setOutputRange(Constants.ELEVATOR_LOW_GEAR_MIN_OUTPUT, Constants.ELEVATOR_LOW_GEAR_MAX_OUTPUT,
+				Constants.LOW_GEAR_PID_SLOT);
 	}
 
 	public void configureOhCrapPID() {
@@ -102,17 +106,37 @@ public class Elevator extends Subsystem {
 	public void setTarget(double rotations) {
 		final int pidSlot = getGearState() ? Constants.HIGH_GEAR_PID_SLOT : Constants.LOW_GEAR_PID_SLOT;
 		// Use the correct top limit position depending on high gear or low gear
+		// High gear
 		if (getGearState()) {
+			// If boolean not triggered, zero if needed.
+			// Prevents elevator from staying at enc position 0 when trying to move up
+			if (!bottomWasPressed) {
+				if (m_bottomLimit.get()) {
+					setPosition(Constants.BOTTOM_LIMIT_POSITION);
+					bottomWasPressed = true;
+				}
+			}
+			// Once the elevator moves enough to be away from the limit, reset the boolean
+			if (!m_bottomLimit.get()) {
+				bottomWasPressed = false;
+			}
 			if (m_topLimit.get()) {
 				setPosition(Constants.TOP_LIMIT_POSITION);
-			} else if (m_bottomLimit.get()) {
-				setPosition(Constants.BOTTOM_LIMIT_POSITION);
 			}
-		} else if (!getGearState()) {
+
+		} else if (!getGearState()) { // Low gear
+			// See above
+			if (!bottomWasPressed) {
+				if (m_bottomLimit.get()) {
+					setPosition(Constants.BOTTOM_LIMIT_POSITION);
+					bottomWasPressed = true;
+				}
+			}
+			if (!m_bottomLimit.get()) {
+				bottomWasPressed = false;
+			}
 			if (m_topLimit.get()) {
 				setPosition(Constants.TOP_LOW_GEAR_LIMIT_POSITION);
-			} else if (m_bottomLimit.get()) {
-				setPosition(Constants.BOTTOM_LIMIT_POSITION);
 			}
 		}
 
@@ -214,6 +238,10 @@ public class Elevator extends Subsystem {
 	 */
 	public void setPosition(double rotations) {
 		m_elevatorMotors.getMasterMotor().setEncPosition(rotations);
+	}
+
+	public double getAppliedOutput() {
+		return m_elevatorMotors.getMasterMotor().getAppliedOutput();
 	}
 
 	/**

--- a/src/main/java/frc/robot/subsystems/elevator/commands/ManualZero.java
+++ b/src/main/java/frc/robot/subsystems/elevator/commands/ManualZero.java
@@ -20,7 +20,8 @@ public class ManualZero extends Command {
   // Called just before this Command runs the first time
   @Override
   protected void initialize() {
-    Robot.elevator.setPosition(0);
+	Robot.elevator.setPosition(0);
+	Robot.elevator.setWasBottomed(true);
   }
 
   // Called repeatedly when this Command is scheduled to run

--- a/src/main/java/frc/robot/subsystems/elevator/commands/ManualZero.java
+++ b/src/main/java/frc/robot/subsystems/elevator/commands/ManualZero.java
@@ -1,0 +1,47 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.subsystems.elevator.commands;
+
+import edu.wpi.first.wpilibj.command.Command;
+import frc.robot.Robot;
+
+public class ManualZero extends Command {
+  public ManualZero() {
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+    requires(Robot.elevator);
+  }
+
+  // Called just before this Command runs the first time
+  @Override
+  protected void initialize() {
+    Robot.elevator.setPosition(0);
+  }
+
+  // Called repeatedly when this Command is scheduled to run
+  @Override
+  protected void execute() {
+  }
+
+  // Make this return true when this Command no longer needs to run execute()
+  @Override
+  protected boolean isFinished() {
+    return false;
+  }
+
+  // Called once after isFinished returns true
+  @Override
+  protected void end() {
+  }
+
+  // Called when another command which requires one or more of the same
+  // subsystems is scheduled to run
+  @Override
+  protected void interrupted() {
+  }
+}


### PR DESCRIPTION
One known issue:
Elevator will crunch at bottom when manual zero'ed and then a setpoint is used, as well as when the elevator is moved to the bottom manually to zero with the limit switch. Workaround is to zero again just after the setpoint which will move it to the correct height.